### PR TITLE
Remove pod security annotations for now

### DIFF
--- a/helm/linkerd-bundle/values.yaml
+++ b/helm/linkerd-bundle/values.yaml
@@ -13,7 +13,6 @@ apps:
       labels:
         linkerd.io/cni-resource: "true"
         config.linkerd.io/admission-webhooks: disabled
-        pod-security.kubernetes.io/enforce: privileged
     # used by renovate
     # repo: giantswarm/linkerd2-cni-app
     version: 0.8.0
@@ -36,7 +35,6 @@ apps:
         linkerd.io/is-control-plane: "true"
         config.linkerd.io/admission-webhooks: disabled
         linkerd.io/control-plane-ns: linkerd
-        pod-security.kubernetes.io/enforce: restricted
     # used by renovate
     # repo: giantswarm/linkerd-control-plane-app
     version: 0.9.0


### PR DESCRIPTION
Linkerd-control-plane is not yet prepared for enforcing the restricted
psp

Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:

- adds/changes/removes etc

### Testing

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
