### PR TITLE
Revert "Group renovate updates"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,7 @@
       "fileMatch": ["^helm\\/.+\\/values\\.yaml$"],
       "matchStrings": ["repo: (?<depName>.*)\n(\\s)*version: (?<currentValue>.*?)\n"],
       "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$",
-      "groupName": "apps",
-      "automerge": true
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "schedule": [ "after 6am on thursday" ]


### PR DESCRIPTION
Reverts giantswarm/linkerd-bundle#32

the fields are not allowed for regexManagers https://github.com/giantswarm/linkerd-bundle/issues/33