### PR TITLE
Add kubeconfig secret to app template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Promote bundle to stable catalog.
+- Add kubeconfig secret to AppCR template.
 
 ## [0.3.0] - 2023-03-09
 

--- a/helm/linkerd-bundle/templates/apps.yaml
+++ b/helm/linkerd-bundle/templates/apps.yaml
@@ -24,10 +24,13 @@ spec:
   install:
     skipCRDs: {{.skipCRDs | default false }}
     timeout: 10m
-  upgrade: 
+  upgrade:
     timeout: 10m
   kubeConfig:
     inCluster: false
+    secret:
+      name: {{ $.Values.clusterID }}-kubeconfig
+      namespace: {{ $.Release.Namespace}}
   name: {{ .chartName }}
   namespace: {{ .namespace }}
   {{- with .namespaceConfig }}


### PR DESCRIPTION
This PR adds the kubeconfig secret name and namespace fields to the AppCR templates.

Tested this on AWS and Azure vintage.

### Testing

- [x] fresh install works
  - [x] AWS vintage
  - [x] Azure vintage


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
